### PR TITLE
Allow to define auth token for quay.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
   - "3.8"
 install:
-  - pip install requests service_identity codecov
+  - pip install requests service_identity codecov flake8
 script:
-  - python setup.py flake8
+  - flake8
   - python setup.py test
 after_script:
   - codecov

--- a/repotracker.ini
+++ b/repotracker.ini
@@ -9,9 +9,12 @@ topic_prefix = VirtualTopic.eng.repotracker
 [datanommer]
 type = container
 repo = quay.io/factory2/datanommer
-tags = latest stage prod
 
 [datagrepper]
 type = container
 repo = quay.io/factory2/datagrepper
-tags = latest stage prod
+
+[secretrepo]
+type = container
+repo = quay.io/factory2/secret
+token_env = FACTORY2_QUAY_TOKEN

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright 2018 Mike Bonnet <mikeb@redhat.com>
 
+import pytest
 from unittest.mock import patch, MagicMock
 producer_mock = MagicMock()
 patch.dict('sys.modules', values={'rhmsg.activemq.producer': producer_mock}).start()
-from repotracker import cli
-import pytest
+
+from repotracker import cli  # noqa: E402
 
 
 @patch('sys.argv', new=['foo'])
@@ -14,8 +15,8 @@ def test_get_args_default():
     Test that get_args() returns the expected default values.
     """
     args = cli.get_args()
-    assert args.quiet == False
-    assert args.verbose == False
+    assert args.quiet is False
+    assert args.verbose is False
     assert args.config == '/etc/repotracker/repotracker.ini'
     assert args.data == '/var/lib/repotracker/containers/repotracker-containers.json'
 
@@ -26,8 +27,8 @@ def test_get_args_all():
     Test that get_args() respects all command-line options.
     """
     args = cli.get_args()
-    assert args.quiet == True
-    assert args.verbose == True
+    assert args.quiet is True
+    assert args.verbose is True
     assert args.config == '/repotracker.ini'
     assert args.data == '/data.json'
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -727,7 +727,8 @@ def test_quay_latest(get):
     get.return_value.json.return_value = QUAY_API_DATA
     result = container.check_repos(CONF, {})
     get.assert_called_once_with(
-        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={}
     )
     assert result == {
         'quay.io/repos/testrepo': {
@@ -747,6 +748,36 @@ def test_quay_latest(get):
     }
 
 
+@patch.dict(CONF['test'], repo='quay.io/repos/testrepo', token_env="ENV_TOKEN")
+@patch.dict(container.os.environ, {"ENV_TOKEN": "TOKEN"})
+@patch.object(container.requests, 'get', autospec=True)
+def test_quay_token(get):
+    """
+    Test that token is passed from config.
+    """
+    get.return_value.json.return_value = QUAY_API_DATA
+    result = container.check_repos(CONF, {})
+    get.assert_called_once_with(
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={"Authorization": "Bearer TOKEN"}
+    )
+
+
+@patch.dict(CONF['test'], repo='quay.io/repos/testrepo', token_env="ENV_TOKEN")
+@patch.dict(container.os.environ, {})
+@patch.object(container.requests, 'get', autospec=True)
+def test_quay_token_missing(get):
+    """
+    Test missing token in env but defined in config.
+    """
+    get.return_value.json.return_value = QUAY_API_DATA
+    result = container.check_repos(CONF, {})
+    get.assert_called_once_with(
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={}
+    )
+
+
 @patch.dict(CONF['test'], repo='quay.io/repos/testrepo')
 @patch.object(container.requests, 'get', autospec=True)
 def test_quay_multitag(get):
@@ -756,7 +787,8 @@ def test_quay_multitag(get):
     get.return_value.json.return_value = QUAY_API_DATA_MULTITAG
     result = container.check_repos(CONF, {})
     get.assert_called_once_with(
-        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={}
     )
     assert result == {
         'quay.io/repos/testrepo': {
@@ -797,9 +829,18 @@ def test_quay_multipage(get):
     get.return_value.json.side_effect = QUAY_API_DATA_MULTIPAGE
     result = container.check_repos(CONF, {})
     calls = [
-        call('https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'),
-        call('https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=2'),
-        call('https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=3')
+        call(
+            'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+             headers={}
+        ),
+        call(
+            'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=2',
+             headers={}
+        ),
+        call(
+            'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=3',
+             headers={}
+        )
     ]
     get.assert_has_calls(calls, any_order=True)
     assert result == {
@@ -855,8 +896,14 @@ def test_quay_multitag_multipage(get):
     get.return_value.json.side_effect = [QUAY_API_DATA_MULTITAG, QUAY_API_DATA]
     result = container.check_repos(CONF, {})
     calls = [
-        call('https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'),
-        call('https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=2')
+        call(
+            'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+            headers={}
+        ),
+        call(
+            'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=2',
+            headers={}
+        )
     ]
     get.assert_has_calls(calls, any_order=True)
     assert result == {
@@ -926,7 +973,8 @@ def test_quay_error_unchanged(get):
     }
     result = container.check_repos(CONF, old_data)
     get.assert_called_once_with(
-        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={}
     )
     assert result == {
         'quay.io/repos/testrepo': {
@@ -957,7 +1005,8 @@ def test_quay_duplicate_tag(get):
     get.return_value.json.return_value = QUAY_API_DATA_MULTITAG
     result = container.check_repos(CONF, {})
     get.assert_called_once_with(
-        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1'
+        'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
+        headers={}
     )
     assert result == {
         'quay.io/repos/testrepo': {

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -756,7 +756,7 @@ def test_quay_token(get):
     Test that token is passed from config.
     """
     get.return_value.json.return_value = QUAY_API_DATA
-    result = container.check_repos(CONF, {})
+    container.check_repos(CONF, {})
     get.assert_called_once_with(
         'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
         headers={"Authorization": "Bearer TOKEN"}
@@ -771,7 +771,7 @@ def test_quay_token_missing(get):
     Test missing token in env but defined in config.
     """
     get.return_value.json.return_value = QUAY_API_DATA
-    result = container.check_repos(CONF, {})
+    container.check_repos(CONF, {})
     get.assert_called_once_with(
         'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
         headers={}
@@ -831,16 +831,16 @@ def test_quay_multipage(get):
     calls = [
         call(
             'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=1',
-             headers={}
+            headers={},
         ),
         call(
             'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=2',
-             headers={}
+            headers={},
         ),
         call(
             'https://quay.io/api/v1/repository/repos/testrepo/tag/?onlyActiveTags=true&limit=100&page=3',
-             headers={}
-        )
+            headers={},
+        ),
     ]
     get.assert_has_calls(calls, any_order=True)
     assert result == {

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright 2018 Mike Bonnet <mikeb@redhat.com>
 
+import json
 from unittest.mock import MagicMock, patch, call
 producer_mock = MagicMock()
 patch.dict('sys.modules', values={'rhmsg.activemq.producer': producer_mock}).start()
-from repotracker import messaging
-import json
 
+from repotracker import messaging   # noqa: E402
 
 DATA = {
     'example.com/repos/testrepo': {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright 2018 Mike Bonnet <mikeb@redhat.com>
 
-from unittest.mock import patch
 from repotracker import utils
 import json
+
 
 def test_load_config(tmpdir):
     """
@@ -38,7 +38,7 @@ def test_load_data_missing(tmpdir):
     Test that a missing or empty data file does not cause an error.
     """
     data = tmpdir.join('data')
-    assert data.check() == False
+    assert data.check() is False
     result = utils.load_data(str(data))
     assert result == {}
     data.ensure()
@@ -46,7 +46,7 @@ def test_load_data_missing(tmpdir):
     assert data.size() == 0
     result = utils.load_data(str(data))
     assert result == {}
-    
+
 
 def test_load_data(tmpdir):
     """
@@ -141,5 +141,5 @@ def test_format_time_empty():
     """
     Test that format_time() handles empty values correctly.
     """
-    assert utils.format_time(None) == None
-    assert utils.format_time('') == None
+    assert utils.format_time(None) is None
+    assert utils.format_time('') is None


### PR DESCRIPTION
Quay can contain private repositories. Allow to access them using token
in environment variable.