### PR TITLE
Bump fedora version from f32 to f35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:35
 LABEL \
     name="repotracker" \
     vendor="EXD SP" \


### PR DESCRIPTION
It was no longer possible to build the image from Dockerfile, because python-rhmsg is no longer supported for f32.