### PR TITLE
Lower fedora version from f35 to f34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:34
 LABEL \
     name="repotracker" \
     vendor="EXD SP" \


### PR DESCRIPTION
python-rhsmg module is not available for f35. Fixes #15 