### PR TITLE
build and install rhmsg as part of the container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,42 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:latest
 
 LABEL \
     name="repotracker" \
-    vendor="EXD SP" \
+    vendor="Red Hat Software Production" \
     maintainer="C3I Guild <exd-guild-c3i@redhat.com>" \
     license="GPLv3" \
     description="A microservice for tracking container repositories, and publishing a message when they change." \
     usage="https://github.com/release-engineering/repotracker"
 
-ARG DNF_CMD="dnf -y --setopt=deltarpm=0 --setopt=install_weak_deps=false --setopt=tsflags=nodocs"
+ARG DNF_CMD="dnf -y --repo=fedora,updates --setopt=deltarpm=False --setopt=install_weak_deps=False --setopt=tsflags=nodocs"
+ARG PIP_CMD="python3 -m pip install -v --no-build-isolation --no-cache-dir --prefix=/usr --compile"
+
+ARG RHMSG_REF="refs/heads/master"
+ARG RHMSG_COMMIT="FETCH_HEAD"
+ARG RHMSG_DEPTH="10"
 
 CMD ["/usr/bin/repotracker"]
 
-COPY repos/ /etc/yum.repos.d/
-RUN ${DNF_CMD} install python3-pip python3-requests python3-service-identity python3-rhmsg skopeo && dnf -y clean all
-WORKDIR /src
-COPY . .
-RUN python3 setup.py install --prefix /usr
+ADD https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
+    https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
+    /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
 
+RUN ${DNF_CMD} install python3-pip python3-setuptools python3-wheel \
+                       python3-requests python3-service-identity python3-idna python-idna-ssl python3-qpid-proton \
+                       git-core skopeo && \
+    dnf -y clean all
+
+WORKDIR /src/rhmsg
+RUN git init . && \
+    git fetch --depth=$RHMSG_DEPTH https://gitlab.cee.redhat.com/exd-guild-messaging/rhmsg.git \
+        "${RHMSG_REF}:refs/remotes/origin/${RHMSG_REF##*/}" && \
+    git checkout "$RHMSG_COMMIT"
+RUN $PIP_CMD .
+
+WORKDIR /src/repotracker
+COPY . .
+RUN $PIP_CMD .
+
+WORKDIR /
 USER 1001

--- a/repos/copr-python-rhmsg-fedora.repo
+++ b/repos/copr-python-rhmsg-fedora.repo
@@ -1,9 +1,0 @@
-[copr-python-rhmsg-fedora]
-name=Copr repo for python-rhmsg (Fedora $releasever)
-baseurl=https://copr-be.cloud.fedoraproject.org/results/mikeb/python-rhmsg/fedora-$releasever-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/mikeb/python-rhmsg/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1


### PR DESCRIPTION
This change removes the dependency on the COPR repos for rhmsg, since the rhmsg source repo can now be accessed directly during the build process.