### PR TITLE
Allow users to specify quay repositories

### DIFF
--- a/repotracker/repotracker.ini
+++ b/repotracker/repotracker.ini
@@ -6,6 +6,9 @@ key = /etc/repotracker/key.pem
 cacerts = /etc/pki/tls/certs/ca-bundle.crt
 topic_prefix = VirtualTopic.eng.repotracker
 
+[quayrepos]
+repos=quay.io,images.paas.redhat.com
+
 [datanommer]
 type = container
 repo = quay.io/factory2/datanommer


### PR DESCRIPTION
Proposing a new configuration where users can specify which of their additional registries are Quay. This is useful because Quay API is much faster than going through skopeo.

Another way we could go about this is by creating a check for /api/v1/$repo (Looking at https://docs.quay.io/api/swagger/ , there doesn't seem to be a version endpoint we could use to be 100% sure it's a Quay API) to see if given registry exposes Quay API. But that might not be as reliable or nice as this.

Also split the `inspect_repo` function into two distinct functions to make our approaches more obvious.

@mikebonnet WDYT?

P.S. I'm also experimenting with running skopeo in threads to speed up non-quay repo checks. But that will go into a separate MR.